### PR TITLE
[Feature] /group endpoints

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,7 @@ corelib = { version = "0.1.0", path = "../corelib" }
 axum = { version = "0.8.1", features = ["multipart", "macros"] }
 tokio = { version = "1.43.0", features = ["rt", "macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7.14", features = ["io"] }
-rusqlite = { version = "0.34.0", features = ["bundled", "array"] }
+rusqlite = { version = "0.34.0", features = ["bundled", "vtab", "array"] }
 serde = { version = "1.0.219", features = ["derive"] }
 
 [dev-dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -8,7 +8,7 @@ corelib = { version = "0.1.0", path = "../corelib" }
 axum = { version = "0.8.1", features = ["multipart", "macros"] }
 tokio = { version = "1.43.0", features = ["rt", "macros", "fs", "rt-multi-thread"] }
 tokio-util = { version = "0.7.14", features = ["io"] }
-rusqlite = { version = "0.34.0", features = ["bundled"] }
+rusqlite = { version = "0.34.0", features = ["bundled", "array"] }
 serde = { version = "1.0.219", features = ["derive"] }
 
 [dev-dependencies]

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -206,6 +206,9 @@ pub fn get_existing_users(
     conn: &Connection,
     users: Vec<(i64, String)>,
 ) -> Result<Vec<(i64, String)>> {
+    // use a repeated statement because we can't use rarray
+    // since rarray requires Rc<Vec<Value>>, and Value is only
+    // Text, Integer, Real, or Blob. We need a tuple, so we do it ourselves
     let mut repeated = "(?, ?),".repeat(users.len());
     repeated.pop(); // remove the last comma
     let sql = format!("SELECT id, email FROM users WHERE (id, email) IN ({repeated});");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,7 +3,7 @@ mod db;
 
 use std::env;
 
-use api::{HandlerState, authenticated, connection_task};
+use api::{HandlerState, authenticated, connection_task, get_group_by_id};
 use axum::{
     Router,
     routing::{get, post},
@@ -27,6 +27,14 @@ async fn main() {
         .route("/api/v1/list-files", auth(get(api::list_files)))
         .route("/api/v1/file", auth(get(api::get_file)))
         .route("/api/v1/file", auth(post(api::upload_file)))
+        .route("/api/v1/group/{group_id}", auth(get(get_group_by_id)))
+        .route(
+            "/api/v1/group/{group_id}/key",
+            auth(get(api::get_group_key_by_id)),
+        )
+        .route("/api/v1/group", auth(get(api::get_group_by_members)))
+        .route("/api/v1/group", auth(post(api::create_group)))
+        .route("/api/v1/list-groups", auth(get(api::list_groups)))
         .route("/", get(api::hello))
         .with_state(state);
 


### PR DESCRIPTION
* /group/{group_id} (GET) - returns all the members in the given group, if the user is part of the group
* /group/{group_id}/key (GET) - returns the group key, encrypted for the calling user, if the user is part of the group
* /group (POST) - create a group with the given members, or return a CONFLICT if one already exists
* /group (GET) - retrieve the group_id for the given members, or return a 404 if none exists
* /list-groups (GET) - lists the groups that a user is in