### PR TITLE
[Feature] Listing files from the CLI

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -469,3 +469,38 @@ pub fn upload(
     let result: FileId = resp.json()?;
     Ok(result.file_id)
 }
+
+/// retrieves a list of all files from the server
+///
+/// # Arguments
+///
+/// * `server_url` - the url of the server
+/// * `email` - the email of the user
+/// * `encoded_password` - the base64-encoded password of the user
+///
+/// # Returns
+///
+/// * `file_info` - vector of all the file infos
+pub fn list_files(
+    server_url: &str,
+    email: &str,
+    encoded_password: &str,
+) -> Result<FileInfos, Box<dyn Error>> {
+    let client = reqwest::blocking::Client::new();
+    let resp = client
+        .get(format!(
+            "{server_url}/api/v1/list-files?user_email={email}&user_password_hash={encoded_password}",
+        ))
+        .send()?;
+
+    if !resp.status().is_success() {
+        return Err(Box::from(format!(
+            "Server responded to user info request with:\nStatus: {}\nResponse: {}",
+            resp.status(),
+            resp.text()?
+        )));
+    }
+
+    let files: FileInfos = resp.json()?;
+    Ok(files)
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use clap::{Parser, Subcommand};
-use cli::{download, get_user_info, register, upload};
+use cli::{download, get_user_info, list_files, register, upload};
 use rpassword::read_password;
 use std::{
     env, fs,
@@ -27,6 +27,8 @@ struct Cli {
 enum Subcommands {
     /// Register a new account with the provided email and password credentials.
     Register {},
+    /// List all files associated with this account
+    List {},
     /// Download and decrypt a file from the server
     Download {
         /// The ID of the file to download
@@ -154,6 +156,21 @@ fn main() {
                 Err(e) => println!("Failed to upload file: {e}"),
             }
         }
+        Subcommands::List {} => match list_files(SERVER_URL, &args.email, &encoded_password) {
+            Ok(file_infos) => {
+                println!("{:<20} {:<10} {:<15} {:<10}", "file_name", "file_id", "group_name", "group_id");
+                println!("{}", "-".repeat(60));
+
+                // Print each file info
+                for file in file_infos.files {
+                    println!(
+                        "{:<20} {:<10} {:<15} {:<10}",
+                        file.file_name, file.file_id, file.group_name, file.group_id
+                    );
+                }
+            }
+            Err(e) => println!("Failed to list files: {e}"),
+        },
         Subcommands::Register {} => unreachable!(),
     }
 }


### PR DESCRIPTION
Hey, currently got it to work where we list files from the API. just curious what you guys think abt how to format the output.

currently im doing this, where i pad each column
```rust
println!("{:<20} {:<10} {:<15} {:<10}", "file_name", "file_id", "group_name", "group_id");
println!("{}", "-".repeat(60));

// Print each file info
for file in file_infos.files {
    println!(
        "{:<20} {:<10} {:<15} {:<10}",
        file.file_name, file.file_id, file.group_name, file.group_id
    );
}
```

however it can look weird with a long file name, ex:
```
file_name            file_id    group_name      group_id  
------------------------------------------------------------
Cargo.toml           1          group_1         1         
main.rs              2          group_1         1         
this_is_a_test_file_with_a_stupid_long_name_for_an_example.txt 3          group_1         1         
```

what do you guys think? do we truncate the names in cases like this?