### PR TITLE
[BugFix] File naming constraints #14

### DIFF
--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -393,12 +393,15 @@ pub(crate) async fn ws_file_upload(
                                 if similar_names.contains(&file_name) {
                                     let mut max_num = 0;
                                     for similar in similar_names {
-                                        if similar.starts_with(base_name) && similar.ends_with(&ext) {
+                                        if similar.starts_with(base_name) && similar.ends_with(&ext)
+                                        {
                                             let prefix_len = base_name.len();
                                             let suffix_len = ext.len();
                                             if similar.len() > prefix_len + suffix_len {
-                                                let middle = &similar[prefix_len..(similar.len() - suffix_len)];
-                                                if middle.starts_with(" (") && middle.ends_with(")") {
+                                                let middle = &similar
+                                                    [prefix_len..(similar.len() - suffix_len)];
+                                                if middle.starts_with(" (") && middle.ends_with(")")
+                                                {
                                                     let num_str = &middle[2..middle.len() - 1];
                                                     if let Ok(num) = num_str.parse::<u32>() {
                                                         // set max num if this name has a higher number

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -374,6 +374,45 @@ pub(crate) async fn ws_file_upload(
                             _ => {
                                 file_name = text.to_string();
 
+                                // check if file already exists in group
+                                let mut file_exists = match HandlerState::run_with_db(&st, |db| {
+                                    db::check_file_exists_in_group(db, params.group_id, &file_name)
+                                }) {
+                                    Ok(exists) => exists,
+                                    Err(e) => {
+                                        println!("Failed to query db for existing file with {e:?}");
+                                        return;
+                                    }
+                                };
+
+                                // split the filename into base and extension
+                                let (base_name, ext) = match file_name.rsplit_once('.') {
+                                    Some((base, e)) => (base, format!(".{}", e)),
+                                    None => (file_name.as_str(), String::new()),
+                                };
+
+                                let mut current_check_name = file_name.clone();
+                                let mut file_number = 1;
+
+                                while file_exists {
+                                    // make the new name to check
+                                    current_check_name = format!("{} ({}){}", base_name, file_number, ext);
+
+                                    file_exists = match HandlerState::run_with_db(&st, |db| {
+                                        db::check_file_exists_in_group(db, params.group_id, &current_check_name)
+                                    }) {
+                                        Ok(exists) => exists,
+                                        Err(e) => {
+                                            println!("Failed to query db for existing file with {e:?}");
+                                            return;
+                                        }
+                                    };
+
+                                    file_number += 1;
+                                }
+                                // update the actual file_name
+                                file_name = current_check_name;
+
                                 // insert into DB
                                 // first, initialize channel to connection thread
                                 let (tx, rx) = oneshot::channel();

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -374,51 +374,43 @@ pub(crate) async fn ws_file_upload(
                             _ => {
                                 file_name = text.to_string();
 
-                                // check if file already exists in group
-                                let mut file_exists = match HandlerState::run_with_db(&st, |db| {
-                                    db::check_file_exists_in_group(db, params.group_id, &file_name)
-                                }) {
-                                    Ok(exists) => exists,
-                                    Err(e) => {
-                                        println!("Failed to query db for existing file with {e:?}");
-                                        return;
-                                    }
-                                };
-
                                 // split the filename into base and extension
                                 let (base_name, ext) = match file_name.rsplit_once('.') {
                                     Some((base, e)) => (base, format!(".{}", e)),
                                     None => (file_name.as_str(), String::new()),
                                 };
 
-                                let mut current_check_name = file_name.clone();
-                                let mut file_number = 1;
+                                let similar_names = match HandlerState::run_with_db(&st, |db| {
+                                    db::get_similar_filenames(db, params.group_id, base_name, &ext)
+                                }) {
+                                    Ok(files) => files,
+                                    Err(e) => {
+                                        println!("Failed to query db for similar files with {e:?}");
+                                        return;
+                                    }
+                                };
 
-                                while file_exists {
-                                    // make the new name to check
-                                    current_check_name =
-                                        format!("{} ({}){}", base_name, file_number, ext);
-
-                                    file_exists = match HandlerState::run_with_db(&st, |db| {
-                                        db::check_file_exists_in_group(
-                                            db,
-                                            params.group_id,
-                                            &current_check_name,
-                                        )
-                                    }) {
-                                        Ok(exists) => exists,
-                                        Err(e) => {
-                                            println!(
-                                                "Failed to query db for existing file with {e:?}"
-                                            );
-                                            return;
+                                if similar_names.contains(&file_name) {
+                                    let mut max_num = 0;
+                                    for similar in similar_names {
+                                        if similar.starts_with(base_name) && similar.ends_with(&ext) {
+                                            let prefix_len = base_name.len();
+                                            let suffix_len = ext.len();
+                                            if similar.len() > prefix_len + suffix_len {
+                                                let middle = &similar[prefix_len..(similar.len() - suffix_len)];
+                                                if middle.starts_with(" (") && middle.ends_with(")") {
+                                                    let num_str = &middle[2..middle.len() - 1];
+                                                    if let Ok(num) = num_str.parse::<u32>() {
+                                                        // set max num if this name has a higher number
+                                                        max_num = max_num.max(num);
+                                                    }
+                                                }
+                                            }
                                         }
-                                    };
-
-                                    file_number += 1;
+                                    }
+                                    // put the max number in the file name
+                                    file_name = format!("{} ({}){}", base_name, max_num + 1, ext);
                                 }
-                                // update the actual file_name
-                                file_name = current_check_name;
 
                                 // insert into DB
                                 // first, initialize channel to connection thread

--- a/server/src/api.rs
+++ b/server/src/api.rs
@@ -396,14 +396,21 @@ pub(crate) async fn ws_file_upload(
 
                                 while file_exists {
                                     // make the new name to check
-                                    current_check_name = format!("{} ({}){}", base_name, file_number, ext);
+                                    current_check_name =
+                                        format!("{} ({}){}", base_name, file_number, ext);
 
                                     file_exists = match HandlerState::run_with_db(&st, |db| {
-                                        db::check_file_exists_in_group(db, params.group_id, &current_check_name)
+                                        db::check_file_exists_in_group(
+                                            db,
+                                            params.group_id,
+                                            &current_check_name,
+                                        )
                                     }) {
                                         Ok(exists) => exists,
                                         Err(e) => {
-                                            println!("Failed to query db for existing file with {e:?}");
+                                            println!(
+                                                "Failed to query db for existing file with {e:?}"
+                                            );
                                             return;
                                         }
                                     };

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -181,27 +181,6 @@ pub fn get_user_id_from_email(Database { conn }: &Database, user_email: &str) ->
     statement.query_row(params![user_email], |row| row.get(0))
 }
 
-/// Checks if a file with the given name already exists in the given group.
-///
-/// # Arguments
-///
-/// * `conn` - A reference to the SQLite database connection.
-/// * `group_id` - The ID of the group.
-/// * `filename` - The name of the file to check.
-///
-/// # Returns
-///
-/// A `Result` containing a boolean indicating if the file exists.
-pub fn check_file_exists_in_group(
-    Database { conn }: &Database,
-    group_id: i64,
-    filename: &str,
-) -> Result<bool> {
-    let query = "SELECT EXISTS(SELECT 1 FROM files WHERE group_id = ? AND filename = ? LIMIT 1);";
-    let mut statement = conn.prepare(query)?;
-    statement.query_row(params![group_id, filename], |row| row.get(0))
-}
-
 /// Retrieves filenames in a group that pattern match with the `base_name` and ending `ext`.
 ///
 /// # Arguments

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -203,7 +203,7 @@ pub fn check_file_exists_in_group(
 }
 
 /// Retrieves filenames in a group that begin with the given base string.
-/// 
+///
 /// # Arguments
 ///
 /// * `conn` - A reference to the SQLite database connection.
@@ -223,8 +223,10 @@ pub fn get_similar_filenames(
     let pattern = format!("{}%{}", base_name, ext);
     let query = "SELECT filename FROM files WHERE group_id = ? AND filename LIKE ?";
     let mut statement = conn.prepare(query)?;
-    let filenames = statement.query_map(params![group_id, pattern], |row| row.get::<usize, String>(0))?;
-    
+    let filenames = statement.query_map(params![group_id, pattern], |row| {
+        row.get::<usize, String>(0)
+    })?;
+
     let mut result = Vec::new();
     for name in filenames {
         result.push(name?);

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -202,7 +202,7 @@ pub fn check_file_exists_in_group(
     statement.query_row(params![group_id, filename], |row| row.get(0))
 }
 
-/// Retrieves filenames in a group that begin with the given base string.
+/// Retrieves filenames in a group that pattern match with the `base_name` and ending `ext`.
 ///
 /// # Arguments
 ///
@@ -213,7 +213,7 @@ pub fn check_file_exists_in_group(
 ///
 /// # Returns
 ///
-/// A `Result` containing a list of existing similar file names in the group
+/// A `Result` containing a list of existing similar file names in the group.
 pub fn get_similar_filenames(
     Database { conn }: &Database,
     group_id: i64,

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -192,7 +192,11 @@ pub fn get_user_id_from_email(Database { conn }: &Database, user_email: &str) ->
 /// # Returns
 ///
 /// A `Result` containing a boolean indicating if the file exists.
-pub fn check_file_exists_in_group(Database { conn }: &Database, group_id: i64, filename: &str) -> Result<bool> {
+pub fn check_file_exists_in_group(
+    Database { conn }: &Database,
+    group_id: i64,
+    filename: &str,
+) -> Result<bool> {
     let query = "SELECT EXISTS(SELECT 1 FROM files WHERE group_id = ? AND filename = ? LIMIT 1);";
     let mut statement = conn.prepare(query)?;
     statement.query_row(params![group_id, filename], |row| row.get(0))

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -202,6 +202,36 @@ pub fn check_file_exists_in_group(
     statement.query_row(params![group_id, filename], |row| row.get(0))
 }
 
+/// Retrieves filenames in a group that begin with the given base string.
+/// 
+/// # Arguments
+///
+/// * `conn` - A reference to the SQLite database connection.
+/// * `group_id` - The ID of the group.
+/// * `base_name` - The name of the file to check, before the extension.
+///  * `ext` - The file extension part of the file name.
+///
+/// # Returns
+///
+/// A `Result` containing a list of existing similar file names in the group
+pub fn get_similar_filenames(
+    Database { conn }: &Database,
+    group_id: i64,
+    base_name: &str,
+    ext: &str,
+) -> Result<Vec<String>> {
+    let pattern = format!("{}%{}", base_name, ext);
+    let query = "SELECT filename FROM files WHERE group_id = ? AND filename LIKE ?";
+    let mut statement = conn.prepare(query)?;
+    let filenames = statement.query_map(params![group_id, pattern], |row| row.get::<usize, String>(0))?;
+    
+    let mut result = Vec::new();
+    for name in filenames {
+        result.push(name?);
+    }
+    Ok(result)
+}
+
 /// Inserts a file into the database.
 ///
 /// # Arguments

--- a/server/src/db.rs
+++ b/server/src/db.rs
@@ -181,6 +181,23 @@ pub fn get_user_id_from_email(Database { conn }: &Database, user_email: &str) ->
     statement.query_row(params![user_email], |row| row.get(0))
 }
 
+/// Checks if a file with the given name already exists in the given group.
+///
+/// # Arguments
+///
+/// * `conn` - A reference to the SQLite database connection.
+/// * `group_id` - The ID of the group.
+/// * `filename` - The name of the file to check.
+///
+/// # Returns
+///
+/// A `Result` containing a boolean indicating if the file exists.
+pub fn check_file_exists_in_group(Database { conn }: &Database, group_id: i64, filename: &str) -> Result<bool> {
+    let query = "SELECT EXISTS(SELECT 1 FROM files WHERE group_id = ? AND filename = ? LIMIT 1);";
+    let mut statement = conn.prepare(query)?;
+    statement.query_row(params![group_id, filename], |row| row.get(0))
+}
+
 /// Inserts a file into the database.
 ///
 /// # Arguments


### PR DESCRIPTION
If the file name is already present in the group, a number in () is appended to the file name, before the file extension part.

An old implementation involved building a new string and then re-querying the db everytime we check if "name (1).ext", "name (2).ext"... exists already. Could be problematic if a bunch of these duplicates exist, so instead it gets filenames that pattern match with the first part of the file name and file extension suffix with a % wildcard in-between, and then finds in these the max number in () that appears.

If three files called "name (1).ext" are uploaded to the same group, the second upload becomes "name (1) (1).ext" and the third upload "name (1) (2).ext".

closes #14 